### PR TITLE
Don't print optopt with usage

### DIFF
--- a/tcprtt.c
+++ b/tcprtt.c
@@ -121,7 +121,7 @@ main(int argc, char *argv[])
 int
 usage()
 {
-	printf("Syntax: tcprtt [-f] <host> <port>%d\n", optopt);
+	printf("Syntax: tcprtt [-f] <host> <port>\n");
 	return(EX_USAGE);
 }
 


### PR DESCRIPTION
With optopt being printed the usage output looks like:

    Syntax: tcprtt [-f] <host> <port>0